### PR TITLE
ci(build): trying build on 4core instance

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       dockerfiles: ${{ steps.scan.outputs.dockerfiles }}
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-4core
     needs: setup
     strategy:
       fail-fast: false


### PR DESCRIPTION
started getting segfaults I can't replicate locally. Trying instance used to build shipping docker builds